### PR TITLE
chore: use ankane/pgvector:latest on main (hotfix)

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -102,7 +102,7 @@ jobs:
     needs: fast-sqlite
     services:
       postgres:
-        image: ankane/pgvector:postgres-16
+        image: ankane/pgvector:latest
         env:
           POSTGRES_USER: aicmo
           POSTGRES_PASSWORD: pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         # CI steps that `CREATE EXTENSION IF NOT EXISTS vector;` succeed.
         # We intentionally use the ankane/pgvector image here for the taste-pgvector
         # job which verifies vector-related functionality.
-        image: ankane/pgvector:postgres-16
+        image: ankane/pgvector:latest
         ports: ['5432:5432']
         env:
           POSTGRES_USER: postgres

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ seed:
 .PHONY: db-up db-down db-migrate db-seed smoke-versions smoke-telemetry test-versions test-taste
 
 db-up:
-	docker run -d --rm --name aicmo-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 ankane/pgvector:postgres-16
+	docker run -d --rm --name aicmo-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 ankane/pgvector:latest
 
 db-down:
 	docker stop aicmo-pg || true

--- a/docker-compose.pg.yml
+++ b/docker-compose.pg.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   pg:
-  image: ankane/pgvector:postgres-16
+    image: ankane/pgvector:latest
     environment:
       POSTGRES_PASSWORD: postgres
     ports:


### PR DESCRIPTION
Small hotfix: replace ankane/pgvector:postgres-16 with ankane/pgvector:latest in workflows and Makefile so main CI can pull the image. This mirrors earlier fixes on the feature branch.